### PR TITLE
Обновление mock-файлов для Memory Game

### DIFF
--- a/src/mocks/widgets/memory-game/gc-001.json
+++ b/src/mocks/widgets/memory-game/gc-001.json
@@ -3,7 +3,7 @@
   "type": "memory-game",
   "version": 1,
   "difficulty": 2,
-  "tags": ["garbage-collection", "memory", "reachability"],
+  "tags": ["js-basics", "objects-prototypes"],
   "payload": {
     "codeSnippet": "let a = {val: 1};\nlet b = a;\na = null;",
     "highlightedLine": 3,

--- a/src/mocks/widgets/memory-game/gc-002.json
+++ b/src/mocks/widgets/memory-game/gc-002.json
@@ -3,7 +3,7 @@
   "type": "memory-game",
   "version": 1,
   "difficulty": 3,
-  "tags": ["garbage-collection", "cycles"],
+  "tags": ["objects-prototypes"],
   "payload": {
     "codeSnippet": "let obj1 = {};\nlet obj2 = {};\nobj1.ref = obj2;\nobj2.ref = obj1;\nobj1 = null;\nobj2 = null;",
     "highlightedLine": 6,

--- a/src/mocks/widgets/memory-game/gc-003.json
+++ b/src/mocks/widgets/memory-game/gc-003.json
@@ -3,7 +3,7 @@
   "type": "memory-game",
   "version": 1,
   "difficulty": 1,
-  "tags": ["garbage-collection", "simple"],
+  "tags": ["js-basics"],
   "payload": {
     "codeSnippet": "let user = {name: 'Alice'};\nlet admin = user;\nadmin = null;\nuser = null;",
     "highlightedLine": 4,

--- a/src/mocks/widgets/memory-game/gc-004.json
+++ b/src/mocks/widgets/memory-game/gc-004.json
@@ -3,7 +3,7 @@
   "type": "memory-game",
   "version": 1,
   "difficulty": 2,
-  "tags": ["garbage-collection", "reachability"],
+  "tags": ["js-basics"],
   "payload": {
     "codeSnippet": "let data = {value: 42};\nlet backup = data;\ndata = null;",
     "highlightedLine": 3,

--- a/src/mocks/widgets/memory-game/gc-005.json
+++ b/src/mocks/widgets/memory-game/gc-005.json
@@ -3,7 +3,7 @@
   "type": "memory-game",
   "version": 1,
   "difficulty": 2,
-  "tags": ["garbage-collection", "nested"],
+  "tags": ["objects-prototypes"],
   "payload": {
     "codeSnippet": "let container = { inner: { value: 10 } };\ncontainer = null;",
     "highlightedLine": 2,

--- a/src/mocks/widgets/memory-game/gc-006.json
+++ b/src/mocks/widgets/memory-game/gc-006.json
@@ -3,7 +3,7 @@
   "type": "memory-game",
   "version": 1,
   "difficulty": 3,
-  "tags": ["garbage-collection", "closure"],
+  "tags": ["closures"],
   "payload": {
     "codeSnippet": "function createHolder() {\n  let obj = { data: 'secret' };\n  return function() { return obj; };\n}\nconst holder = createHolder();",
     "highlightedLine": 5,

--- a/src/mocks/widgets/memory-game/gc-007.json
+++ b/src/mocks/widgets/memory-game/gc-007.json
@@ -3,7 +3,7 @@
   "type": "memory-game",
   "version": 1,
   "difficulty": 3,
-  "tags": ["garbage-collection", "cycles"],
+  "tags": ["objects-prototypes"],
   "payload": {
     "codeSnippet": "let a = {};\nlet b = { ref: a };\na.ref = b;\na = null;\nb = null;",
     "highlightedLine": 5,

--- a/src/mocks/widgets/memory-game/gc-008.json
+++ b/src/mocks/widgets/memory-game/gc-008.json
@@ -3,7 +3,7 @@
   "type": "memory-game",
   "version": 1,
   "difficulty": 2,
-  "tags": ["garbage-collection", "array"],
+  "tags": ["arrays-methods"],
   "payload": {
     "codeSnippet": "let arr = [{x:1}, {x:2}];\nlet last = arr.pop();",
     "highlightedLine": 2,

--- a/src/mocks/widgets/memory-game/gc-009.json
+++ b/src/mocks/widgets/memory-game/gc-009.json
@@ -3,7 +3,7 @@
   "type": "memory-game",
   "version": 1,
   "difficulty": 1,
-  "tags": ["garbage-collection", "global"],
+  "tags": ["js-basics", "objects-prototypes"],
   "payload": {
     "codeSnippet": "window.temp = { data: 'leak' };\nwindow.temp = null;",
     "highlightedLine": 2,

--- a/src/mocks/widgets/memory-game/gc-010.json
+++ b/src/mocks/widgets/memory-game/gc-010.json
@@ -3,7 +3,7 @@
   "type": "memory-game",
   "version": 1,
   "difficulty": 2,
-  "tags": ["garbage-collection", "dom"],
+  "tags": ["js-basics"],
   "payload": {
     "codeSnippet": "let div = document.createElement('div');\ndocument.body.appendChild(div);\ndocument.body.removeChild(div);\n// div still referenced",
     "highlightedLine": 4,

--- a/src/mocks/widgets/memory-game/gc-011.json
+++ b/src/mocks/widgets/memory-game/gc-011.json
@@ -2,7 +2,7 @@
   "id": "gc-011",
   "type": "memory-game",
   "version": 1,
-  "difficulty": 1,
+  "difficulty": 2,
   "tags": ["js-basics"],
   "payload": {
     "codeSnippet": "let a = 10;\nlet b = a;\na = null;",

--- a/src/mocks/widgets/memory-game/gc-011.json
+++ b/src/mocks/widgets/memory-game/gc-011.json
@@ -1,0 +1,26 @@
+{
+  "id": "gc-011",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 1,
+  "tags": ["js-basics"],
+  "payload": {
+    "codeSnippet": "let a = 10;\nlet b = a;\na = null;",
+    "highlightedLine": 3,
+    "objects": [
+      { "id": "var-a", "label": "Variable a", "x": 100, "y": 150 },
+      { "id": "var-b", "label": "Variable b", "x": 500, "y": 150 },
+      { "id": "num-10", "label": "Number 10", "x": 300, "y": 280 }
+    ],
+    "links": [
+      { "from": "var-a", "to": "num-10", "label": "ref" },
+      { "from": "var-b", "to": "num-10", "label": "ref" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "var-a" },
+      { "from": "global", "to": "var-b" }
+    ]
+  },
+  "correctAnswer": []
+}

--- a/src/mocks/widgets/memory-game/gc-012.json
+++ b/src/mocks/widgets/memory-game/gc-012.json
@@ -1,0 +1,19 @@
+{
+  "id": "gc-012",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 1,
+  "tags": ["js-basics"],
+  "payload": {
+    "codeSnippet": "let x = {val: 1};\nx = null;",
+    "highlightedLine": 2,
+    "objects": [
+      { "id": "var-x", "label": "Variable x", "x": 100, "y": 150 },
+      { "id": "obj", "label": "Object {val: 1}", "x": 350, "y": 250 }
+    ],
+    "links": [{ "from": "var-x", "to": "obj", "label": "ref" }],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "var-x" }]
+  },
+  "correctAnswer": ["obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-013.json
+++ b/src/mocks/widgets/memory-game/gc-013.json
@@ -1,0 +1,26 @@
+{
+  "id": "gc-013",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 1,
+  "tags": ["js-basics"],
+  "payload": {
+    "codeSnippet": "let y = {val: 2};\nlet z = y;\ny = null;",
+    "highlightedLine": 3,
+    "objects": [
+      { "id": "var-y", "label": "Variable y", "x": 100, "y": 150 },
+      { "id": "var-z", "label": "Variable z", "x": 500, "y": 150 },
+      { "id": "obj", "label": "Object {val: 2}", "x": 300, "y": 280 }
+    ],
+    "links": [
+      { "from": "var-y", "to": "obj", "label": "ref" },
+      { "from": "var-z", "to": "obj", "label": "ref" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "var-y" },
+      { "from": "global", "to": "var-z" }
+    ]
+  },
+  "correctAnswer": []
+}

--- a/src/mocks/widgets/memory-game/gc-014.json
+++ b/src/mocks/widgets/memory-game/gc-014.json
@@ -2,7 +2,7 @@
   "id": "gc-014",
   "type": "memory-game",
   "version": 1,
-  "difficulty": 2,
+  "difficulty": 3,
   "tags": ["js-basics"],
   "payload": {
     "codeSnippet": "let arr = [1, 2];\narr = null;",

--- a/src/mocks/widgets/memory-game/gc-014.json
+++ b/src/mocks/widgets/memory-game/gc-014.json
@@ -1,0 +1,25 @@
+{
+  "id": "gc-014",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["js-basics"],
+  "payload": {
+    "codeSnippet": "let arr = [1, 2];\narr = null;",
+    "highlightedLine": 2,
+    "objects": [
+      { "id": "var-arr", "label": "Variable arr", "x": 100, "y": 150 },
+      { "id": "arr-obj", "label": "Array [1, 2]", "x": 450, "y": 150 },
+      { "id": "elem1", "label": "Number 1", "x": 150, "y": 300 },
+      { "id": "elem2", "label": "Number 2", "x": 450, "y": 300 }
+    ],
+    "links": [
+      { "from": "var-arr", "to": "arr-obj", "label": "ref" },
+      { "from": "arr-obj", "to": "elem1", "label": "0" },
+      { "from": "arr-obj", "to": "elem2", "label": "1" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "var-arr" }]
+  },
+  "correctAnswer": ["arr-obj", "elem1", "elem2"]
+}

--- a/src/mocks/widgets/memory-game/gc-015.json
+++ b/src/mocks/widgets/memory-game/gc-015.json
@@ -1,0 +1,20 @@
+{
+  "id": "gc-015",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 1,
+  "tags": ["js-basics"],
+  "payload": {
+    "codeSnippet": "let flag = true;\nflag = false;",
+    "highlightedLine": 2,
+    "objects": [
+      { "id": "var-flag", "label": "Variable flag", "x": 100, "y": 150 },
+      { "id": "true-val", "label": "Boolean true", "x": 400, "y": 150 },
+      { "id": "false-val", "label": "Boolean false", "x": 400, "y": 300 }
+    ],
+    "links": [{ "from": "var-flag", "to": "false-val", "label": "ref" }],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "var-flag" }]
+  },
+  "correctAnswer": []
+}

--- a/src/mocks/widgets/memory-game/gc-016.json
+++ b/src/mocks/widgets/memory-game/gc-016.json
@@ -1,0 +1,29 @@
+{
+  "id": "gc-016",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["arrays-methods"],
+  "payload": {
+    "codeSnippet": "let nums = [{val:1}, {val:2}];\nlet first = nums.shift();",
+    "highlightedLine": 2,
+    "objects": [
+      { "id": "nums-var", "label": "Variable nums", "x": 50, "y": 150 },
+      { "id": "nums-array", "label": "Array [obj1, obj2]", "x": 300, "y": 150 },
+      { "id": "obj1", "label": "{val:1}", "x": 50, "y": 300 },
+      { "id": "obj2", "label": "{val:2}", "x": 300, "y": 300 },
+      { "id": "first-var", "label": "Variable first", "x": 550, "y": 150 }
+    ],
+    "links": [
+      { "from": "nums-var", "to": "nums-array", "label": "ref" },
+      { "from": "nums-array", "to": "obj2", "label": "0" },
+      { "from": "first-var", "to": "obj1", "label": "ref" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "nums-var" },
+      { "from": "global", "to": "first-var" }
+    ]
+  },
+  "correctAnswer": []
+}

--- a/src/mocks/widgets/memory-game/gc-017.json
+++ b/src/mocks/widgets/memory-game/gc-017.json
@@ -1,0 +1,29 @@
+{
+  "id": "gc-017",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["arrays-methods"],
+  "payload": {
+    "codeSnippet": "let fruits = [{name: 'apple'}, {name: 'banana'}];\nlet last = fruits.pop();",
+    "highlightedLine": 2,
+    "objects": [
+      { "id": "fruits-var", "label": "Variable fruits", "x": 50, "y": 150 },
+      { "id": "fruits-array", "label": "Array [apple]", "x": 300, "y": 150 },
+      { "id": "apple-obj", "label": "{name: 'apple'}", "x": 300, "y": 300 },
+      { "id": "banana-obj", "label": "{name: 'banana'}", "x": 50, "y": 300 },
+      { "id": "last-var", "label": "Variable last", "x": 550, "y": 150 }
+    ],
+    "links": [
+      { "from": "fruits-var", "to": "fruits-array", "label": "ref" },
+      { "from": "fruits-array", "to": "apple-obj", "label": "0" },
+      { "from": "last-var", "to": "banana-obj", "label": "ref" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "fruits-var" },
+      { "from": "global", "to": "last-var" }
+    ]
+  },
+  "correctAnswer": []
+}

--- a/src/mocks/widgets/memory-game/gc-017.json
+++ b/src/mocks/widgets/memory-game/gc-017.json
@@ -2,7 +2,7 @@
   "id": "gc-017",
   "type": "memory-game",
   "version": 1,
-  "difficulty": 2,
+  "difficulty": 1,
   "tags": ["arrays-methods"],
   "payload": {
     "codeSnippet": "let fruits = [{name: 'apple'}, {name: 'banana'}];\nlet last = fruits.pop();",

--- a/src/mocks/widgets/memory-game/gc-018.json
+++ b/src/mocks/widgets/memory-game/gc-018.json
@@ -1,0 +1,31 @@
+{
+  "id": "gc-018",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["arrays-methods"],
+  "payload": {
+    "codeSnippet": "let items = [{id:1}, {id:2}, {id:3}];\nlet removed = items.splice(1, 1);",
+    "highlightedLine": 2,
+    "objects": [
+      { "id": "items-var", "label": "Variable items", "x": 50, "y": 150 },
+      { "id": "items-array", "label": "Array [obj1, obj3]", "x": 300, "y": 150 },
+      { "id": "obj1", "label": "{id:1}", "x": 300, "y": 300 },
+      { "id": "obj2", "label": "{id:2}", "x": 50, "y": 300 },
+      { "id": "obj3", "label": "{id:3}", "x": 550, "y": 300 },
+      { "id": "removed-var", "label": "Variable removed", "x": 550, "y": 150 }
+    ],
+    "links": [
+      { "from": "items-var", "to": "items-array", "label": "ref" },
+      { "from": "items-array", "to": "obj1", "label": "0" },
+      { "from": "items-array", "to": "obj3", "label": "1" },
+      { "from": "removed-var", "to": "obj2", "label": "ref" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "items-var" },
+      { "from": "global", "to": "removed-var" }
+    ]
+  },
+  "correctAnswer": []
+}

--- a/src/mocks/widgets/memory-game/gc-019.json
+++ b/src/mocks/widgets/memory-game/gc-019.json
@@ -1,0 +1,35 @@
+{
+  "id": "gc-019",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["arrays-methods"],
+  "payload": {
+    "codeSnippet": "let original = [{x:1}, {x:2}, {x:3}];\nlet filtered = original.filter(item => item.x > 1);\noriginal = null;",
+    "highlightedLine": 3,
+    "objects": [
+      { "id": "original-var", "label": "Variable original", "x": 50, "y": 120 },
+      { "id": "filtered-var", "label": "Variable filtered", "x": 50, "y": 230 },
+      { "id": "original-array", "label": "Array [obj1, obj2, obj3]", "x": 300, "y": 120 },
+      { "id": "filtered-array", "label": "Array [obj2, obj3]", "x": 300, "y": 230 },
+      { "id": "obj1", "label": "{x:1}", "x": 50, "y": 350 },
+      { "id": "obj2", "label": "{x:2}", "x": 300, "y": 350 },
+      { "id": "obj3", "label": "{x:3}", "x": 550, "y": 350 }
+    ],
+    "links": [
+      { "from": "original-var", "to": "original-array", "label": "ref" },
+      { "from": "filtered-var", "to": "filtered-array", "label": "ref" },
+      { "from": "original-array", "to": "obj1", "label": "0" },
+      { "from": "original-array", "to": "obj2", "label": "1" },
+      { "from": "original-array", "to": "obj3", "label": "2" },
+      { "from": "filtered-array", "to": "obj2", "label": "0" },
+      { "from": "filtered-array", "to": "obj3", "label": "1" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "original-var" },
+      { "from": "global", "to": "filtered-var" }
+    ]
+  },
+  "correctAnswer": ["original-array", "obj1"]
+}

--- a/src/mocks/widgets/memory-game/gc-019.json
+++ b/src/mocks/widgets/memory-game/gc-019.json
@@ -2,7 +2,7 @@
   "id": "gc-019",
   "type": "memory-game",
   "version": 1,
-  "difficulty": 2,
+  "difficulty": 3,
   "tags": ["arrays-methods"],
   "payload": {
     "codeSnippet": "let original = [{x:1}, {x:2}, {x:3}];\nlet filtered = original.filter(item => item.x > 1);\noriginal = null;",

--- a/src/mocks/widgets/memory-game/gc-020.json
+++ b/src/mocks/widgets/memory-game/gc-020.json
@@ -1,0 +1,33 @@
+{
+  "id": "gc-020",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["arrays-methods"],
+  "payload": {
+    "codeSnippet": "let numbers = [{val:10}, {val:20}];\nlet copy = numbers.slice();\nnumbers = null;",
+    "highlightedLine": 3,
+    "objects": [
+      { "id": "numbers-var", "label": "Variable numbers", "x": 50, "y": 120 },
+      { "id": "copy-var", "label": "Variable copy", "x": 50, "y": 270 },
+      { "id": "numbers-array", "label": "Array [obj10, obj20]", "x": 300, "y": 120 },
+      { "id": "copy-array", "label": "Array [obj10, obj20]", "x": 300, "y": 270 },
+      { "id": "obj10", "label": "{val:10}", "x": 550, "y": 200 },
+      { "id": "obj20", "label": "{val:20}", "x": 550, "y": 350 }
+    ],
+    "links": [
+      { "from": "numbers-var", "to": "numbers-array", "label": "ref" },
+      { "from": "copy-var", "to": "copy-array", "label": "ref" },
+      { "from": "numbers-array", "to": "obj10", "label": "0" },
+      { "from": "numbers-array", "to": "obj20", "label": "1" },
+      { "from": "copy-array", "to": "obj10", "label": "0" },
+      { "from": "copy-array", "to": "obj20", "label": "1" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "numbers-var" },
+      { "from": "global", "to": "copy-var" }
+    ]
+  },
+  "correctAnswer": ["numbers-array"]
+}

--- a/src/mocks/widgets/memory-game/gc-021.json
+++ b/src/mocks/widgets/memory-game/gc-021.json
@@ -1,0 +1,30 @@
+{
+  "id": "gc-021",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["comparison-operators"],
+  "payload": {
+    "codeSnippet": "let a = {val:1};\nlet b = {val:1};\nlet same = a === b;\na = null;\nb = null;",
+    "highlightedLine": 4,
+    "objects": [
+      { "id": "var-a", "label": "Variable a", "x": 50, "y": 150 },
+      { "id": "var-b", "label": "Variable b", "x": 300, "y": 150 },
+      { "id": "obj-a", "label": "Object A", "x": 50, "y": 300 },
+      { "id": "obj-b", "label": "Object B", "x": 300, "y": 300 },
+      { "id": "same-var", "label": "Variable same", "x": 550, "y": 150 }
+    ],
+    "links": [
+      { "from": "var-a", "to": "obj-a", "label": "ref" },
+      { "from": "var-b", "to": "obj-b", "label": "ref" },
+      { "from": "same-var", "to": "false", "label": "value" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "var-a" },
+      { "from": "global", "to": "var-b" },
+      { "from": "global", "to": "same-var" }
+    ]
+  },
+  "correctAnswer": ["obj-a", "obj-b"]
+}

--- a/src/mocks/widgets/memory-game/gc-022.json
+++ b/src/mocks/widgets/memory-game/gc-022.json
@@ -1,0 +1,29 @@
+{
+  "id": "gc-022",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["comparison-operators"],
+  "payload": {
+    "codeSnippet": "let a = {val: 5};\nlet b = {val: 10};\nlet result = a.val > b.val;\na = null;\nb = null;",
+    "highlightedLine": 4,
+    "objects": [
+      { "id": "var-a", "label": "Variable a", "x": 100, "y": 120 },
+      { "id": "var-b", "label": "Variable b", "x": 550, "y": 120 },
+      { "id": "obj-a", "label": "Object {val:5}", "x": 100, "y": 300 },
+      { "id": "obj-b", "label": "Object {val:10}", "x": 550, "y": 300 },
+      { "id": "result-var", "label": "Variable result", "x": 350, "y": 210 }
+    ],
+    "links": [
+      { "from": "var-a", "to": "obj-a", "label": "ref" },
+      { "from": "var-b", "to": "obj-b", "label": "ref" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "var-a" },
+      { "from": "global", "to": "var-b" },
+      { "from": "global", "to": "result-var" }
+    ]
+  },
+  "correctAnswer": ["obj-a", "obj-b"]
+}

--- a/src/mocks/widgets/memory-game/gc-023.json
+++ b/src/mocks/widgets/memory-game/gc-023.json
@@ -1,0 +1,29 @@
+{
+  "id": "gc-023",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["comparison-operators"],
+  "payload": {
+    "codeSnippet": "let x = {name: 'Alice'};\nlet y = {name: 'Alice'};\nlet equal = x === y;\nx = null;\ny = null;",
+    "highlightedLine": 4,
+    "objects": [
+      { "id": "var-x", "label": "Variable x", "x": 50, "y": 120 },
+      { "id": "var-y", "label": "Variable y", "x": 550, "y": 120 },
+      { "id": "obj-x", "label": "Object {name:'Alice'}", "x": 50, "y": 250 },
+      { "id": "obj-y", "label": "Object {name:'Alice'}", "x": 550, "y": 250 },
+      { "id": "equal-var", "label": "Variable equal", "x": 300, "y": 200 }
+    ],
+    "links": [
+      { "from": "var-x", "to": "obj-x", "label": "ref" },
+      { "from": "var-y", "to": "obj-y", "label": "ref" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "var-x" },
+      { "from": "global", "to": "var-y" },
+      { "from": "global", "to": "equal-var" }
+    ]
+  },
+  "correctAnswer": ["obj-x", "obj-y"]
+}

--- a/src/mocks/widgets/memory-game/gc-024.json
+++ b/src/mocks/widgets/memory-game/gc-024.json
@@ -1,0 +1,37 @@
+{
+  "id": "gc-024",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["comparison-operators"],
+  "payload": {
+    "codeSnippet": "let a = [1, 2];\nlet b = [1, 2];\nlet same = a == b;\na = null;\nb = null;",
+    "highlightedLine": 4,
+    "objects": [
+      { "id": "var-a", "label": "Variable a", "x": 50, "y": 120 },
+      { "id": "var-b", "label": "Variable b", "x": 550, "y": 120 },
+      { "id": "arr-a", "label": "Array [1,2]", "x": 50, "y": 250 },
+      { "id": "arr-b", "label": "Array [1,2]", "x": 550, "y": 250 },
+      { "id": "elem-a1", "label": "Number 1", "x": 50, "y": 370 },
+      { "id": "elem-a2", "label": "Number 2", "x": 300, "y": 370 },
+      { "id": "elem-b1", "label": "Number 1", "x": 300, "y": 250 },
+      { "id": "elem-b2", "label": "Number 2", "x": 550, "y": 370 },
+      { "id": "same-var", "label": "Variable same", "x": 300, "y": 120 }
+    ],
+    "links": [
+      { "from": "var-a", "to": "arr-a", "label": "ref" },
+      { "from": "var-b", "to": "arr-b", "label": "ref" },
+      { "from": "arr-a", "to": "elem-a1", "label": "0" },
+      { "from": "arr-a", "to": "elem-a2", "label": "1" },
+      { "from": "arr-b", "to": "elem-b1", "label": "0" },
+      { "from": "arr-b", "to": "elem-b2", "label": "1" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "var-a" },
+      { "from": "global", "to": "var-b" },
+      { "from": "global", "to": "same-var" }
+    ]
+  },
+  "correctAnswer": ["arr-a", "arr-b", "elem-a1", "elem-a2", "elem-b1", "elem-b2"]
+}

--- a/src/mocks/widgets/memory-game/gc-024.json
+++ b/src/mocks/widgets/memory-game/gc-024.json
@@ -2,36 +2,38 @@
   "id": "gc-024",
   "type": "memory-game",
   "version": 1,
-  "difficulty": 2,
+  "difficulty": 3,
   "tags": ["comparison-operators"],
   "payload": {
-    "codeSnippet": "let a = [1, 2];\nlet b = [1, 2];\nlet same = a == b;\na = null;\nb = null;",
-    "highlightedLine": 4,
+    "codeSnippet": "let shared = {id: 1};\nlet a = [shared, {x: 2}];\nlet b = [shared, {x: 3}];\nlet same = a === b;\na = null;\nb = null;",
+    "highlightedLine": 5,
     "objects": [
-      { "id": "var-a", "label": "Variable a", "x": 50, "y": 120 },
-      { "id": "var-b", "label": "Variable b", "x": 550, "y": 120 },
-      { "id": "arr-a", "label": "Array [1,2]", "x": 50, "y": 250 },
-      { "id": "arr-b", "label": "Array [1,2]", "x": 550, "y": 250 },
-      { "id": "elem-a1", "label": "Number 1", "x": 50, "y": 370 },
-      { "id": "elem-a2", "label": "Number 2", "x": 300, "y": 370 },
-      { "id": "elem-b1", "label": "Number 1", "x": 300, "y": 250 },
-      { "id": "elem-b2", "label": "Number 2", "x": 550, "y": 370 },
-      { "id": "same-var", "label": "Variable same", "x": 300, "y": 120 }
+      { "id": "shared-var", "label": "Variable shared", "x": 50, "y": 120 },
+      { "id": "shared-obj", "label": "Object {id:1}", "x": 300, "y": 120 },
+      { "id": "var-a", "label": "Variable a", "x": 50, "y": 250 },
+      { "id": "var-b", "label": "Variable b", "x": 50, "y": 370 },
+      { "id": "arr-a", "label": "Array [shared, objA]", "x": 300, "y": 250 },
+      { "id": "arr-b", "label": "Array [shared, objB]", "x": 300, "y": 370 },
+      { "id": "objA", "label": "{x:2}", "x": 550, "y": 250 },
+      { "id": "objB", "label": "{x:3}", "x": 550, "y": 370 },
+      { "id": "same-var", "label": "Variable same", "x": 550, "y": 120 }
     ],
     "links": [
+      { "from": "shared-var", "to": "shared-obj", "label": "ref" },
       { "from": "var-a", "to": "arr-a", "label": "ref" },
       { "from": "var-b", "to": "arr-b", "label": "ref" },
-      { "from": "arr-a", "to": "elem-a1", "label": "0" },
-      { "from": "arr-a", "to": "elem-a2", "label": "1" },
-      { "from": "arr-b", "to": "elem-b1", "label": "0" },
-      { "from": "arr-b", "to": "elem-b2", "label": "1" }
+      { "from": "arr-a", "to": "shared-obj", "label": "0" },
+      { "from": "arr-a", "to": "objA", "label": "1" },
+      { "from": "arr-b", "to": "shared-obj", "label": "0" },
+      { "from": "arr-b", "to": "objB", "label": "1" }
     ],
     "rootIds": ["global"],
     "rootLinks": [
+      { "from": "global", "to": "shared-var" },
       { "from": "global", "to": "var-a" },
       { "from": "global", "to": "var-b" },
       { "from": "global", "to": "same-var" }
     ]
   },
-  "correctAnswer": ["arr-a", "arr-b", "elem-a1", "elem-a2", "elem-b1", "elem-b2"]
+  "correctAnswer": ["arr-a", "arr-b", "objA", "objB"]
 }

--- a/src/mocks/widgets/memory-game/gc-025.json
+++ b/src/mocks/widgets/memory-game/gc-025.json
@@ -1,0 +1,23 @@
+{
+  "id": "gc-025",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["comparison-operators"],
+  "payload": {
+    "codeSnippet": "let obj = {value: 100};\nlet isBig = obj.value > 50;\nobj = null;",
+    "highlightedLine": 3,
+    "objects": [
+      { "id": "var-obj", "label": "Variable obj", "x": 100, "y": 150 },
+      { "id": "obj-entity", "label": "Object {value:100}", "x": 100, "y": 300 },
+      { "id": "isBig-var", "label": "Variable isBig", "x": 500, "y": 150 }
+    ],
+    "links": [{ "from": "var-obj", "to": "obj-entity", "label": "ref" }],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "var-obj" },
+      { "from": "global", "to": "isBig-var" }
+    ]
+  },
+  "correctAnswer": ["obj-entity"]
+}

--- a/src/mocks/widgets/memory-game/gc-025.json
+++ b/src/mocks/widgets/memory-game/gc-025.json
@@ -2,7 +2,7 @@
   "id": "gc-025",
   "type": "memory-game",
   "version": 1,
-  "difficulty": 2,
+  "difficulty": 1,
   "tags": ["comparison-operators"],
   "payload": {
     "codeSnippet": "let obj = {value: 100};\nlet isBig = obj.value > 50;\nobj = null;",

--- a/src/mocks/widgets/memory-game/gc-026.json
+++ b/src/mocks/widgets/memory-game/gc-026.json
@@ -1,0 +1,19 @@
+{
+  "id": "gc-026",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["functions-scope"],
+  "payload": {
+    "codeSnippet": "function run() {\n  let local = {data: 42};\n  return local;\n}\nlet result = run();\nresult = null;",
+    "highlightedLine": 6,
+    "objects": [
+      { "id": "result-var", "label": "Variable result", "x": 100, "y": 150 },
+      { "id": "local-obj", "label": "Object {data:42}", "x": 300, "y": 300 }
+    ],
+    "links": [{ "from": "result-var", "to": "local-obj", "label": "ref" }],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "result-var" }]
+  },
+  "correctAnswer": ["local-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-026.json
+++ b/src/mocks/widgets/memory-game/gc-026.json
@@ -2,7 +2,7 @@
   "id": "gc-026",
   "type": "memory-game",
   "version": 1,
-  "difficulty": 2,
+  "difficulty": 1,
   "tags": ["functions-scope"],
   "payload": {
     "codeSnippet": "function run() {\n  let local = {data: 42};\n  return local;\n}\nlet result = run();\nresult = null;",

--- a/src/mocks/widgets/memory-game/gc-027.json
+++ b/src/mocks/widgets/memory-game/gc-027.json
@@ -1,0 +1,19 @@
+{
+  "id": "gc-027",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["functions-scope"],
+  "payload": {
+    "codeSnippet": "function create() {\n  let local = {data: 42};\n  return local;\n}\nlet result = create();\nresult = null;",
+    "highlightedLine": 6,
+    "objects": [
+      { "id": "result-var", "label": "Variable result", "x": 100, "y": 150 },
+      { "id": "local-obj", "label": "Object {data:42}", "x": 300, "y": 300 }
+    ],
+    "links": [{ "from": "result-var", "to": "local-obj", "label": "ref" }],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "result-var" }]
+  },
+  "correctAnswer": ["local-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-028.json
+++ b/src/mocks/widgets/memory-game/gc-028.json
@@ -1,0 +1,19 @@
+{
+  "id": "gc-028",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["functions-scope"],
+  "payload": {
+    "codeSnippet": "function outer() {\n  let x = {value: 'outer'};\n  function inner() {\n    let y = {value: 'inner'};\n  }\n  inner();\n}\nouter();",
+    "highlightedLine": 6,
+    "objects": [
+      { "id": "x-obj", "label": "Object {value:'outer'}", "x": 100, "y": 150 },
+      { "id": "y-obj", "label": "Object {value:'inner'}", "x": 350, "y": 300 }
+    ],
+    "links": [],
+    "rootIds": ["global"],
+    "rootLinks": []
+  },
+  "correctAnswer": ["x-obj", "y-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-029.json
+++ b/src/mocks/widgets/memory-game/gc-029.json
@@ -2,7 +2,7 @@
   "id": "gc-029",
   "type": "memory-game",
   "version": 1,
-  "difficulty": 2,
+  "difficulty": 3,
   "tags": ["functions-scope"],
   "payload": {
     "codeSnippet": "function makeCounter() {\n  let count = {value: 0};\n  return function() { return count.value++; };\n}\nlet counter = makeCounter();\ncounter = null;",

--- a/src/mocks/widgets/memory-game/gc-029.json
+++ b/src/mocks/widgets/memory-game/gc-029.json
@@ -1,0 +1,23 @@
+{
+  "id": "gc-029",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["functions-scope"],
+  "payload": {
+    "codeSnippet": "function makeCounter() {\n  let count = {value: 0};\n  return function() { return count.value++; };\n}\nlet counter = makeCounter();\ncounter = null;",
+    "highlightedLine": 6,
+    "objects": [
+      { "id": "counter-var", "label": "Variable counter", "x": 100, "y": 150 },
+      { "id": "closure-fn", "label": "Function (closure)", "x": 350, "y": 150 },
+      { "id": "count-obj", "label": "Object {value:0}", "x": 350, "y": 300 }
+    ],
+    "links": [
+      { "from": "counter-var", "to": "closure-fn", "label": "ref" },
+      { "from": "closure-fn", "to": "count-obj", "label": "[[scope]]" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "counter-var" }]
+  },
+  "correctAnswer": ["closure-fn", "count-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-030.json
+++ b/src/mocks/widgets/memory-game/gc-030.json
@@ -2,7 +2,7 @@
   "id": "gc-030",
   "type": "memory-game",
   "version": 1,
-  "difficulty": 2,
+  "difficulty": 1,
   "tags": ["functions-scope"],
   "payload": {
     "codeSnippet": "function run() {\n  let temp = {data: 'temp'};\n  return;\n}\nrun();",

--- a/src/mocks/widgets/memory-game/gc-030.json
+++ b/src/mocks/widgets/memory-game/gc-030.json
@@ -1,0 +1,16 @@
+{
+  "id": "gc-030",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["functions-scope"],
+  "payload": {
+    "codeSnippet": "function run() {\n  let temp = {data: 'temp'};\n  return;\n}\nrun();",
+    "highlightedLine": 5,
+    "objects": [{ "id": "temp-obj", "label": "Object {data:'temp'}", "x": 200, "y": 200 }],
+    "links": [],
+    "rootIds": ["global"],
+    "rootLinks": []
+  },
+  "correctAnswer": ["temp-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-031.json
+++ b/src/mocks/widgets/memory-game/gc-031.json
@@ -1,0 +1,23 @@
+{
+  "id": "gc-031",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["closures"],
+  "payload": {
+    "codeSnippet": "function outer() {\n  let secret = {value: 'x'};\n  return function() { return secret; };\n}\nlet fn = outer();\nfn = null;",
+    "highlightedLine": 6,
+    "objects": [
+      { "id": "fn-var", "label": "Variable fn", "x": 100, "y": 150 },
+      { "id": "closure-fn", "label": "Function (closure)", "x": 350, "y": 150 },
+      { "id": "secret-obj", "label": "Object {value:'x'}", "x": 350, "y": 300 }
+    ],
+    "links": [
+      { "from": "fn-var", "to": "closure-fn", "label": "ref" },
+      { "from": "closure-fn", "to": "secret-obj", "label": "[[scope]]" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "fn-var" }]
+  },
+  "correctAnswer": ["closure-fn", "secret-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-032.json
+++ b/src/mocks/widgets/memory-game/gc-032.json
@@ -1,0 +1,30 @@
+{
+  "id": "gc-032",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 3,
+  "tags": ["closures"],
+  "payload": {
+    "codeSnippet": "let globalObj = {name: 'global'};\nfunction outer() {\n  let local = {inner: globalObj};\n  return function() { return local; };\n}\nlet fn = outer();\nglobalObj = null;\nfn = null;",
+    "highlightedLine": 8,
+    "objects": [
+      { "id": "globalObj-var", "label": "Variable globalObj", "x": 50, "y": 120 },
+      { "id": "fn-var", "label": "Variable fn", "x": 50, "y": 250 },
+      { "id": "global-obj", "label": "Object {name:'global'}", "x": 400, "y": 120 },
+      { "id": "closure-fn", "label": "Function (closure)", "x": 400, "y": 250 },
+      { "id": "local-obj", "label": "Object {inner: ...}", "x": 400, "y": 370 }
+    ],
+    "links": [
+      { "from": "globalObj-var", "to": "global-obj", "label": "ref" },
+      { "from": "fn-var", "to": "closure-fn", "label": "ref" },
+      { "from": "closure-fn", "to": "local-obj", "label": "[[scope]]" },
+      { "from": "local-obj", "to": "global-obj", "label": "inner" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "globalObj-var" },
+      { "from": "global", "to": "fn-var" }
+    ]
+  },
+  "correctAnswer": ["global-obj", "closure-fn", "local-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-033.json
+++ b/src/mocks/widgets/memory-game/gc-033.json
@@ -1,0 +1,23 @@
+{
+  "id": "gc-033",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 1,
+  "tags": ["closures"],
+  "payload": {
+    "codeSnippet": "function createMultiplier(mult) {\n  return function(n) { return mult * n; };\n}\nlet double = createMultiplier(2);\ndouble = null;",
+    "highlightedLine": 5,
+    "objects": [
+      { "id": "double-var", "label": "Variable double", "x": 100, "y": 150 },
+      { "id": "closure-fn", "label": "Function (closure)", "x": 400, "y": 150 },
+      { "id": "mult-value", "label": "Number 2 (captured)", "x": 400, "y": 300 }
+    ],
+    "links": [
+      { "from": "double-var", "to": "closure-fn", "label": "ref" },
+      { "from": "closure-fn", "to": "mult-value", "label": "[[scope]]" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "double-var" }]
+  },
+  "correctAnswer": ["closure-fn", "mult-value"]
+}

--- a/src/mocks/widgets/memory-game/gc-034.json
+++ b/src/mocks/widgets/memory-game/gc-034.json
@@ -1,0 +1,31 @@
+{
+  "id": "gc-034",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 3,
+  "tags": ["closures"],
+  "payload": {
+    "codeSnippet": "let handlers = [];\nfor (var i = 0; i < 3; i++) {\n  handlers.push(function() { return i; });\n}\nhandlers = null;",
+    "highlightedLine": 5,
+    "objects": [
+      { "id": "handlers-var", "label": "Variable handlers", "x": 50, "y": 120 },
+      { "id": "handlers-array", "label": "Array [fn1, fn2, fn3]", "x": 50, "y": 250 },
+      { "id": "fn1", "label": "Function 0", "x": 300, "y": 120 },
+      { "id": "fn2", "label": "Function 1", "x": 300, "y": 250 },
+      { "id": "fn3", "label": "Function 2", "x": 300, "y": 370 },
+      { "id": "i-value", "label": "Variable i (value 3)", "x": 550, "y": 250 }
+    ],
+    "links": [
+      { "from": "handlers-var", "to": "handlers-array", "label": "ref" },
+      { "from": "handlers-array", "to": "fn1", "label": "0" },
+      { "from": "handlers-array", "to": "fn2", "label": "1" },
+      { "from": "handlers-array", "to": "fn3", "label": "2" },
+      { "from": "fn1", "to": "i-value", "label": "[[scope]]" },
+      { "from": "fn2", "to": "i-value", "label": "[[scope]]" },
+      { "from": "fn3", "to": "i-value", "label": "[[scope]]" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "handlers-var" }]
+  },
+  "correctAnswer": ["handlers-array", "fn1", "fn2", "fn3", "i-value"]
+}

--- a/src/mocks/widgets/memory-game/gc-035.json
+++ b/src/mocks/widgets/memory-game/gc-035.json
@@ -1,0 +1,28 @@
+{
+  "id": "gc-035",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 3,
+  "tags": ["closures"],
+  "payload": {
+    "codeSnippet": "function outer() {\n  let data = {name: 'persistent'};\n  return {\n    getData: function() { return data; },\n    clearData: function() { data = null; }\n  };\n}\nlet obj = outer();\nobj.clearData();\nobj = null;",
+    "highlightedLine": 10,
+    "objects": [
+      { "id": "obj-var", "label": "Variable obj", "x": 50, "y": 120 },
+      { "id": "obj-wrapper", "label": "Object {getData, clearData}", "x": 300, "y": 120 },
+      { "id": "getData-fn", "label": "Function getData", "x": 300, "y": 250 },
+      { "id": "clearData-fn", "label": "Function clearData", "x": 300, "y": 370 },
+      { "id": "data-obj", "label": "Object {name:'persistent'}", "x": 550, "y": 250 }
+    ],
+    "links": [
+      { "from": "obj-var", "to": "obj-wrapper", "label": "ref" },
+      { "from": "obj-wrapper", "to": "getData-fn", "label": "getData" },
+      { "from": "obj-wrapper", "to": "clearData-fn", "label": "clearData" },
+      { "from": "getData-fn", "to": "data-obj", "label": "[[scope]]" },
+      { "from": "clearData-fn", "to": "data-obj", "label": "[[scope]]" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "obj-var" }]
+  },
+  "correctAnswer": ["obj-wrapper", "getData-fn", "clearData-fn"]
+}

--- a/src/mocks/widgets/memory-game/gc-036.json
+++ b/src/mocks/widgets/memory-game/gc-036.json
@@ -1,0 +1,19 @@
+{
+  "id": "gc-036",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 1,
+  "tags": ["async"],
+  "payload": {
+    "codeSnippet": "let timer = setTimeout(() => {}, 1000);\nclearTimeout(timer);\ntimer = null;",
+    "highlightedLine": 3,
+    "objects": [
+      { "id": "timer-var", "label": "Variable timer", "x": 100, "y": 150 },
+      { "id": "timeout-id", "label": "Timeout ID", "x": 400, "y": 150 }
+    ],
+    "links": [{ "from": "timer-var", "to": "timeout-id", "label": "ref" }],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "timer-var" }]
+  },
+  "correctAnswer": ["timeout-id"]
+}

--- a/src/mocks/widgets/memory-game/gc-037.json
+++ b/src/mocks/widgets/memory-game/gc-037.json
@@ -1,0 +1,25 @@
+{
+  "id": "gc-037",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["async"],
+  "payload": {
+    "codeSnippet": "let p = new Promise((resolve) => {\n  let data = {loaded: true};\n  resolve(data);\n});\np = null;",
+    "highlightedLine": 5,
+    "objects": [
+      { "id": "p-var", "label": "Variable p", "x": 100, "y": 120 },
+      { "id": "promise-obj", "label": "Promise", "x": 400, "y": 120 },
+      { "id": "executor-fn", "label": "Executor function", "x": 400, "y": 250 },
+      { "id": "data-obj", "label": "Object {loaded:true}", "x": 400, "y": 370 }
+    ],
+    "links": [
+      { "from": "p-var", "to": "promise-obj", "label": "ref" },
+      { "from": "promise-obj", "to": "executor-fn", "label": "[[executor]]" },
+      { "from": "executor-fn", "to": "data-obj", "label": "ref" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "p-var" }]
+  },
+  "correctAnswer": ["promise-obj", "executor-fn", "data-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-038.json
+++ b/src/mocks/widgets/memory-game/gc-038.json
@@ -1,0 +1,28 @@
+{
+  "id": "gc-038",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 3,
+  "tags": ["async"],
+  "payload": {
+    "codeSnippet": "let callback = () => {\n  let data = {value: 42};\n};\nsetTimeout(callback, 1000);\ncallback = null;",
+    "highlightedLine": 5,
+    "objects": [
+      { "id": "callback-var", "label": "Variable callback", "x": 50, "y": 120 },
+      { "id": "callback-fn", "label": "Callback function", "x": 350, "y": 120 },
+      { "id": "timeout-obj", "label": "Timeout (timer)", "x": 550, "y": 250 },
+      { "id": "data-obj", "label": "Object {value:42}", "x": 50, "y": 370 }
+    ],
+    "links": [
+      { "from": "callback-var", "to": "callback-fn", "label": "ref" },
+      { "from": "callback-fn", "to": "data-obj", "label": "[[scope]]" },
+      { "from": "timeout-obj", "to": "callback-fn", "label": "callback" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "callback-var" },
+      { "from": "global", "to": "timeout-obj", "label": "active timers" }
+    ]
+  },
+  "correctAnswer": ["callback-fn", "data-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-039.json
+++ b/src/mocks/widgets/memory-game/gc-039.json
@@ -1,0 +1,25 @@
+{
+  "id": "gc-039",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["async"],
+  "payload": {
+    "codeSnippet": "async function fetchData() {\n  let result = {status: 'ok'};\n  return result;\n}\nlet promise = fetchData();\npromise = null;",
+    "highlightedLine": 6,
+    "objects": [
+      { "id": "promise-var", "label": "Variable promise", "x": 100, "y": 120 },
+      { "id": "promise-obj", "label": "Promise (async function)", "x": 400, "y": 120 },
+      { "id": "async-fn", "label": "Async function", "x": 400, "y": 250 },
+      { "id": "result-obj", "label": "Object {status:'ok'}", "x": 400, "y": 370 }
+    ],
+    "links": [
+      { "from": "promise-var", "to": "promise-obj", "label": "ref" },
+      { "from": "promise-obj", "to": "async-fn", "label": "[[executor]]" },
+      { "from": "async-fn", "to": "result-obj", "label": "ref" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "promise-var" }]
+  },
+  "correctAnswer": ["promise-obj", "async-fn", "result-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-040.json
+++ b/src/mocks/widgets/memory-game/gc-040.json
@@ -1,0 +1,30 @@
+{
+  "id": "gc-040",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 3,
+  "tags": ["async"],
+  "payload": {
+    "codeSnippet": "let handler = {\n  data: {value: 'important'},\n  onClick: () => { console.log(this.data); }\n};\nsetTimeout(handler.onClick, 500);\nhandler = null;",
+    "highlightedLine": 7,
+    "objects": [
+      { "id": "handler-var", "label": "Variable handler", "x": 50, "y": 120 },
+      { "id": "handler-obj", "label": "Object handler", "x": 300, "y": 120 },
+      { "id": "data-obj", "label": "Object {value:'important'}", "x": 300, "y": 250 },
+      { "id": "onClick-fn", "label": "Function onClick", "x": 300, "y": 370 },
+      { "id": "timeout-obj", "label": "Timeout (timer)", "x": 550, "y": 120 }
+    ],
+    "links": [
+      { "from": "handler-var", "to": "handler-obj", "label": "ref" },
+      { "from": "handler-obj", "to": "data-obj", "label": "data" },
+      { "from": "handler-obj", "to": "onClick-fn", "label": "onClick" },
+      { "from": "timeout-obj", "to": "onClick-fn", "label": "callback" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "handler-var" },
+      { "from": "global", "to": "timeout-obj" }
+    ]
+  },
+  "correctAnswer": ["handler-obj", "data-obj", "onClick-fn"]
+}

--- a/src/mocks/widgets/memory-game/gc-041.json
+++ b/src/mocks/widgets/memory-game/gc-041.json
@@ -1,0 +1,28 @@
+{
+  "id": "gc-041",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 1,
+  "tags": ["objects-prototypes"],
+  "payload": {
+    "codeSnippet": "let parent = {x:1};\nlet child = Object.create(parent);\nparent = null;",
+    "highlightedLine": 3,
+    "objects": [
+      { "id": "parent-var", "label": "Variable parent", "x": 100, "y": 150 },
+      { "id": "child-var", "label": "Variable child", "x": 100, "y": 300 },
+      { "id": "parent-obj", "label": "Object {x:1}", "x": 400, "y": 150 },
+      { "id": "child-obj", "label": "Object (prototype parent)", "x": 400, "y": 300 }
+    ],
+    "links": [
+      { "from": "parent-var", "to": "parent-obj", "label": "ref" },
+      { "from": "child-var", "to": "child-obj", "label": "ref" },
+      { "from": "child-obj", "to": "parent-obj", "label": "__proto__" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "parent-var" },
+      { "from": "global", "to": "child-var" }
+    ]
+  },
+  "correctAnswer": ["parent-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-042.json
+++ b/src/mocks/widgets/memory-game/gc-042.json
@@ -1,0 +1,28 @@
+{
+  "id": "gc-042",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["objects-prototypes"],
+  "payload": {
+    "codeSnippet": "let proto = {value: 100};\nlet obj = Object.create(proto);\nproto = null;",
+    "highlightedLine": 3,
+    "objects": [
+      { "id": "proto-var", "label": "Variable proto", "x": 100, "y": 150 },
+      { "id": "obj-var", "label": "Variable obj", "x": 100, "y": 300 },
+      { "id": "proto-obj", "label": "Object {value:100}", "x": 400, "y": 150 },
+      { "id": "obj-entity", "label": "Object (prototype proto)", "x": 400, "y": 300 }
+    ],
+    "links": [
+      { "from": "proto-var", "to": "proto-obj", "label": "ref" },
+      { "from": "obj-var", "to": "obj-entity", "label": "ref" },
+      { "from": "obj-entity", "to": "proto-obj", "label": "__proto__" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "proto-var" },
+      { "from": "global", "to": "obj-var" }
+    ]
+  },
+  "correctAnswer": ["proto-obj"]
+}

--- a/src/mocks/widgets/memory-game/gc-043.json
+++ b/src/mocks/widgets/memory-game/gc-043.json
@@ -1,0 +1,32 @@
+{
+  "id": "gc-043",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 2,
+  "tags": ["objects-prototypes"],
+  "payload": {
+    "codeSnippet": "let a = {name: 'A'};\nlet b = {name: 'B'};\nlet obj = Object.create(a);\nobj.__proto__ = b;\na = null;\nb = null;",
+    "highlightedLine": 5,
+    "objects": [
+      { "id": "var-a", "label": "Variable a", "x": 50, "y": 120 },
+      { "id": "var-b", "label": "Variable b", "x": 50, "y": 250 },
+      { "id": "obj-var", "label": "Variable obj", "x": 50, "y": 370 },
+      { "id": "obj-a", "label": "Object {name:'A'}", "x": 400, "y": 120 },
+      { "id": "obj-b", "label": "Object {name:'B'}", "x": 400, "y": 250 },
+      { "id": "obj-entity", "label": "Object", "x": 400, "y": 370 }
+    ],
+    "links": [
+      { "from": "var-a", "to": "obj-a", "label": "ref" },
+      { "from": "var-b", "to": "obj-b", "label": "ref" },
+      { "from": "obj-var", "to": "obj-entity", "label": "ref" },
+      { "from": "obj-entity", "to": "obj-b", "label": "__proto__" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "var-a" },
+      { "from": "global", "to": "var-b" },
+      { "from": "global", "to": "obj-var" }
+    ]
+  },
+  "correctAnswer": ["obj-a"]
+}

--- a/src/mocks/widgets/memory-game/gc-044.json
+++ b/src/mocks/widgets/memory-game/gc-044.json
@@ -1,0 +1,29 @@
+{
+  "id": "gc-044",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 3,
+  "tags": ["objects-prototypes"],
+  "payload": {
+    "codeSnippet": "let obj1 = {};\nlet obj2 = {};\nobj1.__proto__ = obj2;\nobj2.__proto__ = obj1;\nobj1 = null;\nobj2 = null;",
+    "highlightedLine": 6,
+    "objects": [
+      { "id": "var-obj1", "label": "Variable obj1", "x": 100, "y": 150 },
+      { "id": "var-obj2", "label": "Variable obj2", "x": 100, "y": 300 },
+      { "id": "heap-obj1", "label": "Object 1", "x": 400, "y": 150 },
+      { "id": "heap-obj2", "label": "Object 2", "x": 400, "y": 300 }
+    ],
+    "links": [
+      { "from": "var-obj1", "to": "heap-obj1", "label": "ref" },
+      { "from": "var-obj2", "to": "heap-obj2", "label": "ref" },
+      { "from": "heap-obj1", "to": "heap-obj2", "label": "__proto__" },
+      { "from": "heap-obj2", "to": "heap-obj1", "label": "__proto__" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [
+      { "from": "global", "to": "var-obj1" },
+      { "from": "global", "to": "var-obj2" }
+    ]
+  },
+  "correctAnswer": ["heap-obj1", "heap-obj2"]
+}

--- a/src/mocks/widgets/memory-game/gc-045.json
+++ b/src/mocks/widgets/memory-game/gc-045.json
@@ -1,0 +1,24 @@
+{
+  "id": "gc-045",
+  "type": "memory-game",
+  "version": 1,
+  "difficulty": 3,
+  "tags": ["objects-prototypes"],
+  "payload": {
+    "codeSnippet": "function Parent() { this.value = 10; }\nfunction Child() {}\nChild.prototype = new Parent();\nlet child = new Child();\nChild.prototype = null;\nchild = null;",
+    "highlightedLine": 6,
+    "objects": [
+      { "id": "child-var", "label": "Variable child", "x": 50, "y": 120 },
+      { "id": "child-obj", "label": "Child instance", "x": 350, "y": 120 },
+      { "id": "parent-instance", "label": "Parent instance", "x": 350, "y": 370 },
+      { "id": "proto-link", "label": "__proto__", "x": 550, "y": 250 }
+    ],
+    "links": [
+      { "from": "child-var", "to": "child-obj", "label": "ref" },
+      { "from": "child-obj", "to": "parent-instance", "label": "__proto__" }
+    ],
+    "rootIds": ["global"],
+    "rootLinks": [{ "from": "global", "to": "child-var" }]
+  },
+  "correctAnswer": ["child-obj", "parent-instance"]
+}


### PR DESCRIPTION
## Описание изменений

Добавлены и обновлены JSON-моки для виджета **Memory Game** в папке `src/mocks/widgets/memory-game/`:

- **Обновлены существующие файлы gc-001 … gc-010** – поле `tags` приведено к идентификаторам тем из `topicOptions` (`js-basics`, `arrays-methods`, `comparison-operators`, `functions-scope`, `closures`, `async`, `objects-prototypes`).
- **Созданы новые моки gc-011 … gc-045** (35 файлов) для покрытия всех семи тем с разными уровнями сложности (от 1 до 3).
- **Скорректированы уровни сложности** в некоторых существующих примерах для более равномерного распределения.
- **Исправлена ошибка в gc-015** (ссылка теперь ведёт на `false-val`, а не на `true-val`).

Изменения не затрагивают код движка виджетов, только данные. Это позволяет пользователям видеть в библиотеке тем задания по всем перечисленным топикам, а также обеспечивает корректную фильтрацию и сортировку.

## Связанные задачи

Fixes #89 – задача на обновление моков Memory Game и создание новых под топики.

## Тип изменений

- [x] 🚀 Новая функциональность
- [ ] 🐛 Исправление бага
- [ ] 📚 Документация
- [ ] 🔧 Рефакторинг / улучшение кода
- [ ] ⚡ Оптимизация производительности
- [ ] 🧪 Тесты
- [ ] Другое (укажите):

## Чеклист перед отправкой

- [x] Код проходит линтинг и форматирование (изменены только JSON, ошибок нет)
- [x] TypeScript strict mode соблюдён (JSON не влияют на TS)
- [ ] Добавлены или обновлены тесты (тесты виджетов не требуют изменений, так как структура данных не менялась)
- [x] Проверена работа в браузере Chrome (все виджеты загружаются и корректно отображаются)
- [x] Проверена работа на мобильных устройствах (визуализация графа адаптивна)
- [x] Обновлена документация (комментарии в моках не требуются, в DEVELOPMENT_DIARY добавлена запись о создании новых моков)
- [x] PR не слишком большой (35 новых JSON-файлов + 10 обновлённых – всего ~45 файлов, но каждый файл маленький, суммарно ~500 строк)
- [x] Убедился, что все конфликты с целевой веткой разрешены

## Как тестировать

1. **Проверить загрузку моков через `MockWidgetDataSource`**
   - Убедиться, что `VITE_USE_MOCK=true` в `.env`.
   - Открыть страницу с Memory Game (например, `/memory-game` или через библиотеку тем).
   - Проверить, что все виджеты (gc-001 … gc-045) загружаются без ошибок в консоли.

2. **Проверить соответствие тегов топикам**
   - В библиотеке тем (если она уже интегрирована) выбрать каждый топик (`js-basics`, `arrays-methods`, `comparison-operators`, `functions-scope`, `closures`, `async`, `objects-prototypes`).
   - Убедиться, что в каждом топике отображаются соответствующие виджеты.

3. **Проверить корректность игровой механики для новых моков**
   - Открыть каждый новый виджет (например, gc-011 … gc-045) по очереди.
   - Проверить, что граф объектов отрисовывается правильно (позиции объектов, связи).
   - Попробовать пометить объекты как мусор и нажать «Collect».
   - Сравнить результат с `correctAnswer` в JSON – должно быть либо успешное сообщение, либо ошибка с подсветкой.

4. **Проверить уровни сложности**
   - Для виджетов difficulty 1 (например, gc-012, gc-015, gc-017, gc-025, gc-027, gc-030, gc-036, gc-041) убедиться, что они действительно простые (один-два объекта, очевидный мусор).
   - Для difficulty 3 (gc-019, gc-024, gc-029, gc-032, gc-034, gc-035, gc-038, gc-040, gc-044, gc-045) убедиться, что они содержат нетривиальные сценарии (циклические ссылки, замыкания, асинхронность, сложные цепочки прототипов).

5. **Проверить исправление gc-015**
   - Открыть gc-015.
   - Убедиться, что после выполнения `flag = false` переменная `flag` указывает на `false-val`, а `true-val` отсутствует или не влияет на игру.

## Скриншоты / видео (если применимо)
<img width="2136" height="1155" alt="изображение" src="https://github.com/user-attachments/assets/3657d41e-db80-4ae3-9da7-74708ac6fd42" />

## Дополнительная информация

- Все новые моки имеют сплошную нумерацию от 11 до 45, что упрощает отслеживание.
- Валидация правильных ответов осуществляется через `MemoryGameAnswerValidator`, который не требует изменений.
- Для корректной работы фильтрации по топикам необходимо, чтобы API (или Mock-адаптер) возвращал виджеты с соответствующими `tags`. Это реализовано в `mock-widget-data-source.ts` – он просто загружает JSON, поэтому изменения вступают в силу автоматически.
- Если в будущем понадобится добавить ещё виджеты, рекомендуется продолжать нумерацию с 46.